### PR TITLE
Adds explicit platform requirement on `Package.swift`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,9 @@ import PackageDescription
 
 let package = Package(
     name: "SwiftECC",
+    platforms: [
+        .iOS(.v13),
+    ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(


### PR DESCRIPTION
Including this module as a Swift Package dependency is not working without specifying the platform requirements.