### PR TITLE
feature: Add keyAgreement method that does not hash the computed secret

### DIFF
--- a/SwiftECC.podspec
+++ b/SwiftECC.podspec
@@ -19,8 +19,4 @@ Pod::Spec.new do |s|
   s.dependency 'BigInt'
   s.dependency 'ASN1'
   
-  s.test_spec 'Tests' do |test_spec|
-    test_spec.source_files = 'Tests/**/*.swift'
-    test_spec.dependency 'SwiftECC'
-  end
 end

--- a/SwiftECC.podspec
+++ b/SwiftECC.podspec
@@ -1,0 +1,26 @@
+Pod::Spec.new do |s|
+  s.name         = "SwiftECC"
+  s.version      = "0.1.0" # specify the version here
+  s.summary      = "A short description of SwiftECC." # specify a short description here
+
+  s.description  = <<-DESC
+                   A longer description of SwiftECC.
+                   DESC
+
+  s.homepage     = "https://www.example.com" # replace with the package's homepage
+  s.license      = { :type => 'MIT', :file => 'LICENSE' } # specify the license here
+  s.author       = { "Your Name" => "your_email@example.com" } # replace with the author's name and email
+  s.platform     = :ios, '13.0' # specify the minimum iOS version
+  s.source       = { :git => "https://github.com/username/SwiftECC.git", :tag => s.version.to_s }
+
+  s.swift_version = '5.7'
+  s.source_files  = "Sources/SwiftECC/**/*.swift"
+  
+  s.dependency 'BigInt'
+  s.dependency 'ASN1'
+  
+  s.test_spec 'Tests' do |test_spec|
+    test_spec.source_files = 'Tests/**/*.swift'
+    test_spec.dependency 'SwiftECC'
+  end
+end


### PR DESCRIPTION
This will help make the keyAgreement method compatible with other languages' libraries.

In java for example, you can generate shared secret like this: 
```kotlin
private fun computeSharedSecret(otherPublicKey: PublicKey, myPrivateKey: PrivateKey): ByteArray {
        val keyAgreement = KeyAgreement.getInstance("ECDH")
        keyAgreement.init(myPrivateKey)
        keyAgreement.doPhase(otherPublicKey, true)
        return keyAgreement.generateSecret()
    }
```

In node, you can do it like this: 
```typescript
const myPrivateKey = Buffer.from("iUfaS6XxDCOS65sGqeunCQJR4045pTA3H4cCcYqfLpg", 'base64')
const otherSidePublicKey = Buffer.from("BJPPEL/HhVR4Yv8qyKT/1A8rcRhmP8aXBKCikXeShNhjWWWKjDuKt9zco7Flt9l14uJW1lt2kCIjb8e64wDW5Sg=", 'base64')

const ecdh = crypto.createECDH('secp256k1')
ecdh.setPrivateKey(myPrivateKey)
const sharedSecret = ecdh.computeSecret(otherSidePublicKey)
```

None of these hash the result key. Let's allow generating key like that in this library also.

There is one TODO in this MR that I don't know how to do. 
Since the key is not digested, length is always the same of given curve so it does not make sense to accept it in parameter. I don't know how to calculate shared key's length so that is one thing I need help with.